### PR TITLE
More logger changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,4 @@ NETSUITE_ROLE="1"
 # Logging Options
 #NETSUITE_LOGGING=false
 #NETSUITE_LOG_PATH=
+#NETSUITE_LOGGER="NetSuite\\Logger"

--- a/README.md
+++ b/README.md
@@ -160,6 +160,19 @@ You can also set logging on or off during runtime with methods. Note that
 if you don't specify a logging directory in the config or at runtime, then
 no logs will be created. There must be a valid target location.
 
+You can take full control of logging by providing your own custom logger object
+which implements the provided `NetSuite\LoggerInterface`.
+
+The first method is by defining the `logger` configuration key 
+(`NETSUITE_LOGGER` if loading from `.env`). The value of this key should be
+the class you want to be used instead of the default `NetSuite\Logger` 
+implementation. When the library needs to log a request and has to create one
+on the fly, this class will be used.
+
+The second option is to instantiate your custom logger manually and then
+pass it into the client using the `setLogger` method after instantiating the
+client. Using this method, it isn't required to also set the `logger` option.
+
 ```php
 // Set a logging path
 $service->setLogPath('/path/to/logs');
@@ -170,8 +183,9 @@ $service->logRequests(true);  // Turn logging on.
 // Turn logging off
 $service->logRequests(false); // Turn logging off.
 
-// Use a custom logger - Use Logger.php as sample
-$service->setLogger('MyLogger', '/path/to/logs');
+// Or bring your own logger that implements LoggerInterface
+$logger = new MyCustomLoggerClass('/custom/log/path');
+$service->setLogger($logger);
 ```
 
 ## Generating Classes

--- a/samples/config.php
+++ b/samples/config.php
@@ -2,7 +2,7 @@
 
 // An example of loading your config from environment variables with optional defaults.
 return [
-    'endpoint' => getenv('NETSUITE_ENDPOINT') ?: '2020_0',
+    'endpoint' => getenv('NETSUITE_ENDPOINT') ?: '2020_2',
     'host'     => getenv('NETSUITE_HOST')     ?: 'https://webservices.netsuite.com',
     'email'    => getenv('NETSUITE_EMAIL')    ?: 'jDoe@netsuite.com',
     'password' => getenv('NETSUITE_PASSWORD') ?: 'mySecretPwd',

--- a/samples/config.php
+++ b/samples/config.php
@@ -2,7 +2,7 @@
 
 // An example of loading your config from environment variables with optional defaults.
 return [
-    'endpoint' => getenv('NETSUITE_ENDPOINT') ?: '2017_1',
+    'endpoint' => getenv('NETSUITE_ENDPOINT') ?: '2020_0',
     'host'     => getenv('NETSUITE_HOST')     ?: 'https://webservices.netsuite.com',
     'email'    => getenv('NETSUITE_EMAIL')    ?: 'jDoe@netsuite.com',
     'password' => getenv('NETSUITE_PASSWORD') ?: 'mySecretPwd',

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -2,7 +2,7 @@
 
 namespace NetSuite;
 
-class Logger
+class Logger implements LoggerInterface
 {
     private $path;
 
@@ -12,12 +12,23 @@ class Logger
     }
 
     /**
+     * Set the log file directory on this object.
+     *
+     * @param string $logPath
+     * @return void
+     */
+    public function setLogPath(string $logPath): void
+    {
+        $this->path = $logPath;
+    }
+
+    /**
      * Log the last soap call as request and response XML files.
      *
      * @param \SoapClient $client
      * @param string $operation
      */
-    public function logSoapCall($client, $operation)
+    public function logSoapCall(\SoapClient $client, string $operation): void
     {
         if (file_exists($this->path)) {
             $fileName = "ryanwinchester-netsuite-php-" . date("Ymd.His") . "-" . $operation;

--- a/src/LoggerInterface.php
+++ b/src/LoggerInterface.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Implement this interface when creating custom logger classes for your
+ * application.
+ */
+
+namespace NetSuite;
+
+interface LoggerInterface
+{
+    /**
+     * Instantiation of a Logger accepts an optional path to the folder
+     * where logs should be stored.
+     *
+     * @param string $logPath
+     */
+    public function __construct(string $logPath = null);
+
+    /**
+     * Change the log directory on the fly.
+     *
+     * @param string $logPath
+     * @return void
+     */
+    public function setLogPath(string $logPath): void;
+
+    /**
+     * Log the last soap call run through the given SoapClient.
+     *
+     * @param \SoapClient $client
+     * @param string $operation
+     * @return void
+     */
+    public function logSoapCall(\SoapClient $client, string $operation): void;
+}

--- a/src/NetSuiteClient.php
+++ b/src/NetSuiteClient.php
@@ -93,7 +93,7 @@ class NetSuiteClient
     public static function getEnvConfig()
     {
         $config = [
-            'endpoint'           => getenv('NETSUITE_ENDPOINT') ?: '2020_0',
+            'endpoint'           => getenv('NETSUITE_ENDPOINT') ?: '2020_2',
             'host'               => getenv('NETSUITE_HOST') ?: 'https://webservices.sandbox.netsuite.com',
             'email'              => getenv('NETSUITE_EMAIL'),
             'password'           => getenv('NETSUITE_PASSWORD'),


### PR DESCRIPTION
Hi, myself and another user have already been working to hash out some improvements to logging, but while those issues are still being discussed/resolved, these changes are a bit simpler to vet. On a separate note, I've recently started some offline work toward supporting phpunit testing for this library and part of that upgrade had me already looking at adding getters and setters for the logger object for easier testing/mocking/etc. I made a few minor changes to how you approached the logging stuff, but I think it's a bit more straight-forward/useful this way. Like if the user is already calling setLogger method to name a class to use as the logger, I reasoned we might as well just have them pass in the new logger. I also added a LoggerInterface as a clearer guideline for providing custom Logger implementations. I thought about using the PSR logger interface standard, but it seems a bit overkill for this purpose. Please have a look at the changes I've submitted to your custom-logger branch and let me know if you have any thoughts or concerns to add. If it looks good to use, pull in these changes and I think we can merge the PR in to master.

* Add `getLogger()` to defer logger creation and use the appropriate class/path at that time
* Simplified `setLogger()`
* Add `LoggerInterface` and `setLogPath()` method on Loggers
* Add more typehinting
* Set default web services to 2020_2 because we don't actually have a 2021_1 toolkit yet
* Update README and env example file

Some of the changes that have been in the works separately are custom formatting of log filenames and date formats, etc, but I think this PR solves those issues a little better by simply offering the end user full control over it with a custom logging class if they don't like the library defaults.